### PR TITLE
Manually call meson instead of using the meson task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,11 +3,9 @@
     "tasks": [
         {
             "label": "Meson: Build Unix",
-            "type": "meson",
-            "target": "dagger",
-            "mode": "build",
+            "type": "shell",
             "group": "build",
-            "problemMatcher": []
+            "command": "meson setup builddir && meson compile -C builddir"
         },
         {
             "label": "Meson: Build Windows",


### PR DESCRIPTION
It seems that the meson extension has received an update, and it broke all the run task options it provided :(