### PR TITLE
bugfix: Fixed bouncy players upon landing on a platform and changed h…

### DIFF
--- a/include/GameSpecificComponents.h
+++ b/include/GameSpecificComponents.h
@@ -6,12 +6,11 @@
 #define SCREEN_HEIGHT 600
 #define SPEED_MOD 300.0f
 #define GRAVITY_MOD 400.0f
-#define JUMP_MOD 600.0f
+#define JUMP_MOD 400.0f
 
 struct Player
 {
 	Bool is_grounded;
-	F32 jump_speed;
 	F32 vertical_velocity;
 };
 

--- a/src/Gravity.cpp
+++ b/src/Gravity.cpp
@@ -7,7 +7,7 @@ void GravitySystem::on_tick()
         if (!player.is_grounded)
         {
             player.vertical_velocity += GRAVITY_MOD * Time::delta_time();
-            pos.xy.y += player.vertical_velocity * Time::delta_time();
+            //pos.xy.y += player.vertical_velocity * Time::delta_time();
         }
     }
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -75,7 +75,7 @@ struct SWMG : public Game {
 			.with<Visibility>(true);
 
 		auto player_one = spawn()
-			.with<Player>(false, 0.0f, 0.0f)
+			.with<Player>(false, 0.0f)
 			.with<Sprite>(ecs::no_entity)
 			.with<SpriteAnimation>(Spritesheet::get_by_name("test/WizardIdle"))
 			.with<Position>(geometry::Vec2{ 50, 600 - 32})
@@ -86,7 +86,7 @@ struct SWMG : public Game {
 			.done();
 
 		auto player_two = spawn()
-			.with<Player>(false, 0.0f, 0.0f)
+			.with<Player>(false, 0.0f)
 			.with<Sprite>(ecs::no_entity)
 			.with<SpriteAnimation>(Spritesheet::get_by_name("test/WizardIdle"))
 			.with<Position>(geometry::Vec2{ 750, 600 - 32})

--- a/src/Platform.cpp
+++ b/src/Platform.cpp
@@ -10,10 +10,11 @@ void PlatformSystem::on_tick()
             if (player_pos.xy.x <= platform_pos.xy.x + platform.width / 2 + 11 &&
                 player_pos.xy.x >= platform_pos.xy.x - platform.width / 2 - 11 && 
                 player_pos.xy.y + 16 >= platform_pos.xy.y - 1 && 
-                player_pos.xy.y + 16 <= platform_pos.xy.y + 1) 
+                player_pos.xy.y + 16 <= platform_pos.xy.y + 1 &&
+                player.vertical_velocity >= 0.0f) // last check = check if player is falling
             {
                 on_platform = true;
-                player.vertical_velocity = 0;
+                player.vertical_velocity = 0.0f;
                 break;
             }
         }

--- a/src/PlayerControls.cpp
+++ b/src/PlayerControls.cpp
@@ -8,11 +8,16 @@ void PlayerControlsSystem::on_tick()
     {
         if (keys.is_pressed(bindings.up) && player.is_grounded) // keys.is_down() causes a bug where player can levitate trough platforms 
         {
-            player.jump_speed = JUMP_MOD;
+            player.vertical_velocity = -JUMP_MOD;
+            player.is_grounded = false;
         }
         if (keys.is_down(bindings.down))  // deleted player.is_grounded condition, player can now go down from platform
         {
             pos.xy.y += SPEED_MOD * Time::delta_time();
+            if (player.vertical_velocity < 0.0f)
+            {
+                player.vertical_velocity = 0.0f;
+            }
             if (pos.xy.y > SCREEN_HEIGHT - 16) 
             {
                 pos.xy.y = SCREEN_HEIGHT - 16;
@@ -42,15 +47,12 @@ void PlayerControlsSystem::on_tick()
         {
             sprite.change_to("test/WizardIdle");
         }
-        if (player.jump_speed > 0) 
+        if (keys.is_released(bindings.up) && player.vertical_velocity < 0)
         {
-            pos.xy.y -= player.jump_speed * Time::delta_time();
-            player.jump_speed -= 0.1;
+            player.vertical_velocity/=2;
         }
-        if (keys.is_released(bindings.up))
-        {
-            player.is_grounded = false;
-            player.jump_speed/=2;
-        }
+
+        // Always happening vertical velocity movement
+        pos.xy.y += player.vertical_velocity * Time::delta_time();
     }
 }


### PR DESCRIPTION
…ow gravity and playercontrols systems work

Removed unnecessary jump_speed attribute of player component. Made it so that player vertical_velocity now works in both directions, to take account of both jumping and gravity. Changed how platform collision works, so that it happens only if the player is falling (or standing still on a platform) and not while he is going up in a jump, which had to be done for the newly-implemented vertical_velocity to work. All player position changes now happen in the PlayerControlsSystem, while GravitySystem only changes the vertical_velocity. This kind of kills the point of a gravity system existing separately, but with future plans of creating more entites that are affected by gravity, it should remain in existence.