### PR TITLE
Added gdb to the list of required Liunx programs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ brew install meson sdl2 yaml-cpp
 
 ### Ubuntu 22.04:
 ```sh
-sudo apt install git meson ninja-build clang libyaml-cpp-dev libsdl2-dev
+sudo apt install git meson ninja-build clang gdb libsdl2-dev
 ```
 
 ### Fedora 37:
 ```sh
-sudo dnf install git meson ninja-build clang yaml-cpp-devel SDL2-devel
+sudo dnf install git meson ninja-build clang gdb yaml-cpp-devel SDL2-devel
 ```
 
 ## Clone the repository


### PR DESCRIPTION
Witout gdb VS gives a weird error that some debugger path needs to be specified when trying to run the build.