### PR TITLE
Not allocating a separate fsm for every enemy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -77,5 +77,5 @@
         "variant": "cpp"
     },
     "mesonbuild.configureOnOpen": false,
-    "C_Cpp.default.compileCommands": "builddir/vscode_compile_commands.json"
+    "C_Cpp.default.compileCommands": "builddir\\vscode_compile_commands.json"
 }

--- a/include/EnemyFSMController.h
+++ b/include/EnemyFSMController.h
@@ -4,57 +4,87 @@
 #define ENEMY_DISTANCER 90.0f
 
 #include "EnemyFSM.h"
-// #include "Enemies.h"
 #include "Prelude.h"
 
-struct EnemyFSMController : public ecs::System,
-							public MutAccessStorage<Player>,
-							public MutAccessComponentById<Position>,
-							public MutAccessGroupStorage<Enemy, Position, SpriteAnimation>,
-							public MutAccessComponentById<EnemyFSMController>,
-							public MutAccessStorage<EnemyFSMController>,
-							public MutAccessComponentById<SpriteAnimation>,
-							public MutAccessComponentById<Flip>,
-							public MutAccessComponentById<Enemy>
-
-
+struct EnemyFSMInstance
 {
+	String current_state;
+	String queued_command;
 
+	EnemyFSMInstance(String&& current)
+		: current_state{current}
+		, queued_command{""}
+	{}
+};
+
+struct EnemyFSMController 	
+	: public ecs::System
+	, public AllocateUnique<EnemyFSM>
+	, public MutAccessUnique<EnemyFSM>
+	, public AccessStorage<Player>
+	, public MutAccessComponentById<Position>
+	, public MutAccessGroupStorage<Enemy, Position, SpriteAnimation>
+	, public MutAccessComponentById<SpriteAnimation>
+	, public MutAccessComponentById<Flip>
+	, public MutAccessComponentById<Enemy>
+	, public MutAccessStorage<EnemyFSMInstance>
+{
 	using QueryEnemies = MutAccessGroupStorage<Enemy, Position, SpriteAnimation>;
 
-	EnemyFSM fsm;
 	ecs::Entity enemy_entity_cache;
 	Bool doing_damage = false;
 
-	// Flip &flip = MutAccessComponentById<Flip>::get(enemy_entity_cache);
-	// ecs::Entity player = MutAccessStorage<Player>::access_storage().front();
-	// Position &player_position = MutAccessComponentById<Position>::get(player);
-
-	EnemyFSMController(ecs::Entity entt)
-		: enemy_entity_cache(entt)
+	EnemyFSMController()
+		: enemy_entity_cache(ecs::no_entity)
 	{
-		fsm.events_for_action("TryMove").connect<&EnemyFSMController::TryMove>(this);
-		fsm.events_for_action("TryStop").connect<&EnemyFSMController::TryStop>(this);
-		fsm.events_for_action("TryAttack").connect<&EnemyFSMController::TryAttack>(this);
-		fsm.events_for_action("TryHit").connect<&EnemyFSMController::TryHit>(this);
+		auto& fsm = MutAccessUnique<EnemyFSM>::access_unique();
+		fsm.events_for_action("TryMove").connect<&EnemyFSMController::try_move>(this);
+		fsm.events_for_action("TryStop").connect<&EnemyFSMController::try_stop>(this);
+		fsm.events_for_action("TryAttack").connect<&EnemyFSMController::try_attack>(this);
+		fsm.events_for_action("TryHit").connect<&EnemyFSMController::try_hit>(this);
 		fsm.current_state = "Idle";
 	}
 
-	void TryMove()
-	{
+	void on_tick() override {
+		auto& fsm = MutAccessUnique<EnemyFSM>::access_unique();
+		for (auto&& [entity, instance] : MutAccessStorage<EnemyFSMInstance>::access_storage().each())
+		{
+			enemy_entity_cache = entity;
+			if (instance.queued_command != "")
+			{
+				String next_state;
+				fsm.trigger(instance.queued_command, instance.current_state, next_state);
+				instance.current_state = next_state;
+				instance.queued_command = "";
+			}
+			enemy_entity_cache = ecs::no_entity;
+		}
+	}
 
-		Flip &flip = MutAccessComponentById<Flip>::get(enemy_entity_cache);
-		ecs::Entity player = MutAccessStorage<Player>::access_storage().front();
-		Position &player_position = MutAccessComponentById<Position>::get(player);
-		Enemy &enemy = MutAccessComponentById<Enemy>::get(enemy_entity_cache);
-		Position &pos = MutAccessComponentById<Position>::get(enemy_entity_cache);
+	ecs::Entity get_player() const
+	{
+		static ecs::Entity cached_entity = ecs::no_entity;
+		if (cached_entity != ecs::no_entity)
+		{
+			return cached_entity;
+		}
+
+		cached_entity = AccessStorage<Player>::access_storage().front();
+		return cached_entity;
+	}
+
+	void try_move()
+	{
+		Flip& flip = MutAccessComponentById<Flip>::get(enemy_entity_cache);
+		ecs::Entity player = get_player();
+		Position& player_position = MutAccessComponentById<Position>::get(player);
+		Enemy& enemy = MutAccessComponentById<Enemy>::get(enemy_entity_cache);
+		Position& pos = MutAccessComponentById<Position>::get(enemy_entity_cache);
 
 		auto &sprite = MutAccessComponentById<SpriteAnimation>::get(enemy_entity_cache);
 		sprite.change_to("Golem/Golem1_run");
 
 		auto size = QueryEnemies::access_storage().size_hint();
-		// Logger::info("Current number of enemies {}", size);
-		// enemy flocking system (do this only if there is more then one enemy left)
 		if (size >= 2)
 		{
 
@@ -74,7 +104,6 @@ struct EnemyFSMController : public ecs::System,
 				}
 			}
 
-			// TODO: check length around this...
 			auto to_player = my_normalize(player_position.xy - pos.xy);
 			auto from_nearest_enemy = my_normalize(pos.xy - nearest_enemy_pos->xy);
 
@@ -99,9 +128,8 @@ struct EnemyFSMController : public ecs::System,
 		}
 		else
 		{
-
 			Flip &flip = MutAccessComponentById<Flip>::get(enemy_entity_cache);
-			ecs::Entity player = MutAccessStorage<Player>::access_storage().front();
+			ecs::Entity player = get_player();
 			Position &player_position = MutAccessComponentById<Position>::get(player);
 
 			auto to_player = my_normalize(player_position.xy - pos.xy);
@@ -117,18 +145,18 @@ struct EnemyFSMController : public ecs::System,
 			enemy.speed = my_normalize(enemy.speed);
 			pos.xy += enemy.speed * Time::delta_time() * ENEMY_SPEED_MOD;
 		}
+
 		if (enemy.speed.length == 0)
 		{
 			Logger::critical("Speed is 0 len");
-		}
+		}		
 		else if (pos.xy.length == 0)
 		{
 			Logger::critical("Position is 0 len");
-		}
-		// Logger::info("enemy {}. position {},{} , speed {}, {}", (int)enemy_entity_cache, pos.xy.x, pos.xy.y, enemy.speed.x, enemy.speed.y);
+		}		
 	}
 
-	void TryStop()
+	void try_stop()
 	{
 		auto &sprite = MutAccessComponentById<SpriteAnimation>::get(enemy_entity_cache);
 		sprite.change_to("Golem/Golem1_idle");
@@ -144,12 +172,12 @@ struct EnemyFSMController : public ecs::System,
 		}
 	}
 
-	void TryAttack()
+	void try_attack()
 	{
 		auto &sprite = MutAccessComponentById<SpriteAnimation>::get(enemy_entity_cache);
 		sprite.change_to("Golem/Golem1_attack");
 		Flip &flip = MutAccessComponentById<Flip>::get(enemy_entity_cache);
-		ecs::Entity player = MutAccessStorage<Player>::access_storage().front();
+		ecs::Entity player = get_player();
 		Position &player_position = MutAccessComponentById<Position>::get(player);
 		Position &pos = MutAccessComponentById<Position>::get(enemy_entity_cache);
 
@@ -164,12 +192,12 @@ struct EnemyFSMController : public ecs::System,
 		doing_damage = true;
 	}
 
-	void TryHit()
+	void try_hit()
 	{
 		auto &sprite = MutAccessComponentById<SpriteAnimation>::get(enemy_entity_cache);
 		sprite.change_to("Golem/Golem1_attack");
 
-		ecs::Entity player = MutAccessStorage<Player>::access_storage().front();
+		ecs::Entity player = get_player();
 		Position &player_position = MutAccessComponentById<Position>::get(player);
 		Position &pos = MutAccessComponentById<Position>::get(enemy_entity_cache);
 
@@ -186,25 +214,24 @@ struct EnemyFSMController : public ecs::System,
 	inline Bool should_flip() const
 	{
 		Position &pos = MutAccessComponentById<Position>::get(enemy_entity_cache);
-		ecs::Entity player = MutAccessStorage<Player>::access_storage().front();
+		ecs::Entity player = get_player();
 		Position &player_position = MutAccessComponentById<Position>::get(player);
-		return player_position.xy.x - pos.xy.x < 0;
+		return (player_position.xy.x - pos.xy.x) < 0.0f;
 	}
 
 	geometry::Vec2 my_normalize(geometry::Vec2 vec)
 	{
-		if (vec.length == 0)
+		if (vec.length() == 0.0f)
 		{
 			return geometry::Vec2(0.0f, 0.0f);
 		}
 
 		float magnitude = std::sqrt(vec.x * vec.x + vec.y * vec.y);
-		if (magnitude != 0)
+		if (magnitude != 0.0f)
 		{
 			vec.x /= magnitude;
 			vec.y /= magnitude;
 		}
 		return vec;
 	}
-
 };

--- a/include/FSM.h
+++ b/include/FSM.h
@@ -68,6 +68,26 @@ public:
         return action_dispatch[key].sink<FSMReaction>();
     }
 
+    Bool trigger(Transition transition, State from, State& next)
+    {
+        if (transitions[from].count(transition) == 0)
+        {
+            return false;
+        }
+
+        next = transitions[from][transition];
+        auto& action = transition_with_actions[from][transition];
+        FSMReaction reaction{ from, transition, action, next };
+
+        dispatcher.trigger(reaction);
+        if (is_action_defined(action))
+        {
+            action_dispatch[action].trigger(reaction);
+        }
+
+        return true;
+    }
+
     Bool trigger(Transition transition)
     {
         if (transitions[current_state].count(transition) == 0)

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -20,7 +20,6 @@
 #include "EnemyFSMController.h"
 #include "TimeRender.h"
 
-
 using namespace core;
 
 struct Brawl : public Game
@@ -32,10 +31,10 @@ struct Brawl : public Game
 		engine.use<PhysicsSystem>();
 		engine.use<DamageSystem>();
 		engine.use<EnemiesController>();
+		engine.use<EnemyFSMController>();
 		engine.use<TimeRenderControlSystem>();
 	}
 
-	
 	int num;
 	void on_start() override
 	{
@@ -62,10 +61,8 @@ struct Brawl : public Game
 			.with<Flip>(None)
 			.with<AnimationSpeedController>(15.0f)
 			.with<Enemy>(geometry::Vec2{ 1, 0 }, 90.0f)
-
+			.with<EnemyFSMInstance>("Idle")
 			.done();
-
-		add_component<EnemyFSMController>(enemy2, enemy2);
 
 		num = rand() % RANGE_X;
 		auto enemy3 = spawn()
@@ -77,10 +74,9 @@ struct Brawl : public Game
 			.with<Flip>(None)
 			.with<AnimationSpeedController>(15.0f)
 			.with<Enemy>(geometry::Vec2{ 1, 0 }, 90.0f)
+			.with<EnemyFSMInstance>("Idle")
 			.done();
 		
-		add_component<EnemyFSMController>(enemy3, enemy3);
-
 		num = rand() % RANGE_Y;
 		auto enemy4 = spawn()
 			.with<Sprite>(ecs::no_entity)
@@ -91,10 +87,8 @@ struct Brawl : public Game
 			.with<Flip>(None)
 			.with<AnimationSpeedController>(15.0f)
 			.with<Enemy>(geometry::Vec2{ 1, 0 }, 90.0f)
+			.with<EnemyFSMInstance>("Idle")
 			.done();
-
-		add_component<EnemyFSMController>(enemy4, enemy4);
-		
 
 		num = rand() % RANGE_Y;
 		auto enemy5 = spawn()
@@ -106,10 +100,8 @@ struct Brawl : public Game
 			.with<Flip>(None)
 			.with<AnimationSpeedController>(15.0f)
 			.with<Enemy>(geometry::Vec2{ 1, 0 }, 90.0f)
+			.with<EnemyFSMInstance>("Idle")
 			.done();
-
-		add_component<EnemyFSMController>(enemy5, enemy5);
-
 
 		TimeRender::init();
 		auto time = spawn()

--- a/src/TimeRender.cpp
+++ b/src/TimeRender.cpp
@@ -73,61 +73,55 @@ void TimeRenderControlSystem::on_tick()
 				{
 					num = rand() % RANGE_X;
 					auto enemy2 = spawn()
-									  .with<Sprite>(ecs::no_entity)
-									  .with<Health>(100)
-									  .with<SpriteAnimation>(Spritesheet::get_by_name("Golem/Golem1_idle"))
-									  .with<Position>(geometry::Vec2{num, 0})
-									  .with<Visibility>(true)
-									  .with<Flip>(None)
-									  .with<AnimationSpeedController>(15.0f)
-									  .with<Enemy>(geometry::Vec2{1, 0}, 90.0f)
-
-									  .done();
-
-
-					add_component<EnemyFSMController>(enemy2, enemy2);
+									.with<Sprite>(ecs::no_entity)
+									.with<Health>(100)
+									.with<SpriteAnimation>(Spritesheet::get_by_name("Golem/Golem1_idle"))
+									.with<Position>(geometry::Vec2{num, 0})
+									.with<Visibility>(true)
+									.with<Flip>(None)
+									.with<AnimationSpeedController>(15.0f)
+									.with<Enemy>(geometry::Vec2{1, 0}, 90.0f)
+									.with<EnemyFSMInstance>("Idle")
+									.done();
 
 					num = rand() % RANGE_X;
 					auto enemy3 = spawn()
-									  .with<Sprite>(ecs::no_entity)
-									  .with<Health>(100)
-									  .with<SpriteAnimation>(Spritesheet::get_by_name("Golem/Golem1_idle"))
-									  .with<Position>(geometry::Vec2{num, 600})
-									  .with<Visibility>(true)
-									  .with<Flip>(None)
-									  .with<AnimationSpeedController>(15.0f)
-									  .with<Enemy>(geometry::Vec2{1, 0}, 90.0f)
-									  .done();
-
-					add_component<EnemyFSMController>(enemy3, enemy3);
+									.with<Sprite>(ecs::no_entity)
+									.with<Health>(100)
+									.with<SpriteAnimation>(Spritesheet::get_by_name("Golem/Golem1_idle"))
+									.with<Position>(geometry::Vec2{num, 600})
+									.with<Visibility>(true)
+									.with<Flip>(None)
+									.with<AnimationSpeedController>(15.0f)
+									.with<Enemy>(geometry::Vec2{1, 0}, 90.0f)
+									.with<EnemyFSMInstance>("Idle")
+									.done();
 
 					num = rand() % RANGE_Y;
 					auto enemy4 = spawn()
-									  .with<Sprite>(ecs::no_entity)
-									  .with<Health>(100)
-									  .with<SpriteAnimation>(Spritesheet::get_by_name("Golem/Golem1_idle"))
-									  .with<Position>(geometry::Vec2{0, num})
-									  .with<Visibility>(true)
-									  .with<Flip>(None)
-									  .with<AnimationSpeedController>(15.0f)
-									  .with<Enemy>(geometry::Vec2{1, 0}, 90.0f)
-									  .done();
-
-					add_component<EnemyFSMController>(enemy4, enemy4);
+									.with<Sprite>(ecs::no_entity)
+									.with<Health>(100)
+									.with<SpriteAnimation>(Spritesheet::get_by_name("Golem/Golem1_idle"))
+									.with<Position>(geometry::Vec2{0, num})
+									.with<Visibility>(true)
+									.with<Flip>(None)
+									.with<AnimationSpeedController>(15.0f)
+									.with<Enemy>(geometry::Vec2{1, 0}, 90.0f)
+									.with<EnemyFSMInstance>("Idle")
+									.done();
 
 					num = rand() % RANGE_Y;
 					auto enemy5 = spawn()
-									  .with<Sprite>(ecs::no_entity)
-									  .with<Health>(100)
-									  .with<SpriteAnimation>(Spritesheet::get_by_name("Golem/Golem1_idle"))
-									  .with<Position>(geometry::Vec2{800, num})
-									  .with<Visibility>(true)
-									  .with<Flip>(None)
-									  .with<AnimationSpeedController>(15.0f)
-									  .with<Enemy>(geometry::Vec2{1, 0}, 90.0f)
-									  .done();
-
-					add_component<EnemyFSMController>(enemy5, enemy5);
+									.with<Sprite>(ecs::no_entity)
+									.with<Health>(100)
+									.with<SpriteAnimation>(Spritesheet::get_by_name("Golem/Golem1_idle"))
+									.with<Position>(geometry::Vec2{800, num})
+									.with<Visibility>(true)
+									.with<Flip>(None)
+									.with<AnimationSpeedController>(15.0f)
+									.with<Enemy>(geometry::Vec2{1, 0}, 90.0f)
+									.with<EnemyFSMInstance>("Idle")
+									.done();
 				}
 				numSpawnedEnemies++;
 			}


### PR DESCRIPTION
FSM fixed, hiccup still present, confirming it's not due to the FSM.

### Previous setup:

EnemyFSM - the FSM itself loaded from grasm
EnemyFSMController - a system _and_ component that talks to the FSM holding an entity cached
EnemiesController - queries everything that has EnemyFSMController and changes state

### New setup:

EnemyFSM - the FSM itself loaded from grasm, no changes
EnemyFSMInstance - a small component that has two strings: one for current state, and one for queued command
EnemyFSMController - now just a system; goes through all EnemyFSMInstances and checks for queued commands - if any, change the current state into a new state
EnemiesController - queries everything that has an EnemyFSMInstance and sets the queued command